### PR TITLE
Add level-assignment algorithm, without causality cycle check

### DIFF
--- a/examples/hello.c
+++ b/examples/hello.c
@@ -31,8 +31,7 @@ int startup_handler(Reaction *_self) {
 }
 
 void MyReaction_ctor(MyReaction *self, Reactor *parent) {
-  Reaction_ctor(&self->super, parent, startup_handler, NULL, 0);
-  self->super.level = 0;
+  Reaction_ctor(&self->super, parent, startup_handler, NULL, 0, 0);
 }
 
 void MyReactor_ctor(MyReactor *self, Environment *env) {

--- a/examples/hello_action.c
+++ b/examples/hello_action.c
@@ -52,8 +52,7 @@ int action_handler(Reaction *_self) {
 }
 
 void MyReaction_ctor(MyReaction *self, Reactor *parent) {
-  Reaction_ctor(&self->super, parent, action_handler, self->effects, 1);
-  self->super.level = 0;
+  Reaction_ctor(&self->super, parent, action_handler, self->effects, 1, 0);
 }
 
 void MyReactor_ctor(struct MyReactor *self, Environment *env) {

--- a/examples/hello_timer.c
+++ b/examples/hello_timer.c
@@ -28,8 +28,7 @@ int timer_handler(Reaction *_self) {
 }
 
 void MyReaction_ctor(MyReaction *self, Reactor *parent) {
-  Reaction_ctor(&self->super, parent, timer_handler, NULL, 0);
-  self->super.level = 0;
+  Reaction_ctor(&self->super, parent, timer_handler, NULL, 0, 0);
 }
 
 void MyReactor_ctor(struct MyReactor *self, Environment *env) {

--- a/examples/port_ex.c
+++ b/examples/port_ex.c
@@ -35,8 +35,7 @@ int timer_handler(Reaction *_self) {
 }
 
 void Reaction1_ctor(Reaction1 *self, Reactor *parent) {
-  Reaction_ctor(&self->super, parent, timer_handler, NULL, 0);
-  self->super.level = 0;
+  Reaction_ctor(&self->super, parent, timer_handler, NULL, 0, 0);
 }
 
 void Out_ctor(Out *self, struct Sender *parent) {
@@ -90,8 +89,7 @@ int input_handler(Reaction *_self) {
 }
 
 void Reaction2_ctor(Reaction2 *self, Reactor *parent) {
-  Reaction_ctor(&self->super, parent, input_handler, NULL, 0);
-  self->super.level = 0;
+  Reaction_ctor(&self->super, parent, input_handler, NULL, 0, 0);
 }
 
 void Receiver_ctor(struct Receiver *self, Environment *env) {

--- a/include/reactor-uc/reaction.h
+++ b/include/reactor-uc/reaction.h
@@ -13,13 +13,17 @@ typedef int (*ReactionHandler)(Reaction *);
 struct Reaction {
   Reactor *parent;
   ReactionHandler body;
-  int level;
+  int level; // Negative level means it is invalid.
+  size_t index;
   Trigger **effects;
   size_t effects_size;
   size_t effects_registered;
   void (*register_effect)(Reaction *self, Trigger *effect);
+  size_t (*calculate_level)(Reaction *self);
+  size_t (*get_level)(Reaction *self);
 };
 
-void Reaction_ctor(Reaction *self, Reactor *parent, ReactionHandler body, Trigger **effects, size_t effects_size);
+void Reaction_ctor(Reaction *self, Reactor *parent, ReactionHandler body, Trigger **effects, size_t effects_size,
+                   size_t index);
 
 #endif

--- a/include/reactor-uc/reactor.h
+++ b/include/reactor-uc/reactor.h
@@ -15,6 +15,7 @@ struct Reactor {
   Environment *env;
   void (*assemble)(Reactor *self);
   void (*register_startup)(Reactor *self, Startup *startup);
+  void (*calculate_levels)(Reactor *self);
   Reactor **children;
   size_t children_size;
   Reaction **reactions;

--- a/src/environment.c
+++ b/src/environment.c
@@ -8,6 +8,9 @@ void Environment_assemble(Environment *self) {
   printf("Assembling environment\n");
   self->current_tag.microstep = 0;
   self->current_tag.time = 0;
+
+  printf("Assigning levels\n");
+  self->main->calculate_levels(self->main);
 }
 
 void Environment_start(Environment *self) {

--- a/src/queues.c
+++ b/src/queues.c
@@ -70,7 +70,10 @@ void EventQueue_ctor(EventQueue *self) {
 void ReactionQueue_insert(ReactionQueue *self, Reaction *reaction) {
   assert(reaction);
   assert(reaction->level <= REACTION_QUEUE_SIZE);
+  assert(reaction->level >= 0);
   assert(self->level_size[reaction->level] < REACTION_QUEUE_SIZE);
+  assert(self->curr_level <= reaction->level);
+
   self->array[reaction->level][self->level_size[reaction->level]++] = reaction;
   if (reaction->level > self->max_active_level) {
     self->max_active_level = reaction->level;

--- a/src/reaction.c
+++ b/src/reaction.c
@@ -1,3 +1,4 @@
+#include "reactor-uc/port.h"
 #include "reactor-uc/reaction.h"
 #include "reactor-uc/trigger.h"
 #include "reactor-uc/util.h"
@@ -7,11 +8,61 @@ void Reaction_register_effect(Reaction *self, Trigger *effect) {
   self->effects[self->effects_registered++] = effect;
 }
 
-void Reaction_ctor(Reaction *self, Reactor *parent, ReactionHandler body, Trigger **effects, size_t effects_size) {
+size_t Reaction_get_level(Reaction *self) {
+  if (self->level < 0) {
+    self->level = self->calculate_level(self);
+  }
+  return self->level;
+}
+
+// FIXME: Detect causality cycle also here.
+size_t Reaction_calculate_level(Reaction *self) {
+  size_t max_level = 0;
+
+  // Possibly inherit level from reactions within same reactor with precedence.
+  if (self->index >= 1) {
+    Reaction *reaction_prev_index = self->parent->reactions[self->index - 1];
+    size_t prev_level = reaction_prev_index->get_level(reaction_prev_index);
+    if (prev_level > max_level) {
+      max_level = prev_level;
+    }
+  }
+
+  // Find sources of this reaction by searching through all triggers of parent
+  for (size_t i = 0; i < self->parent->triggers_size; i++) {
+    Trigger *trigger = self->parent->triggers[i];
+    if (trigger->type == INPUT) {
+      for (size_t j = 0; j < trigger->effects_size; j++) {
+        if (trigger->effects[j] == self) {
+          InputPort *port = (InputPort *)trigger;
+          if (port->super.conn_in) {
+            OutputPort *final_upstream_port = port->super.conn_in->get_final_upstream(port->super.conn_in);
+            for (size_t k = 0; k < final_upstream_port->super.super.sources_size; k++) {
+              Reaction *upstream = final_upstream_port->super.super.sources[k];
+              size_t upstream_level = upstream->get_level(upstream) + 1;
+              if (upstream_level > max_level) {
+                max_level = upstream_level;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return max_level;
+}
+
+void Reaction_ctor(Reaction *self, Reactor *parent, ReactionHandler body, Trigger **effects, size_t effects_size,
+                   size_t index) {
   self->body = body;
   self->parent = parent;
   self->effects = effects;
   self->effects_size = effects_size;
   self->effects_registered = 0;
   self->register_effect = Reaction_register_effect;
+  self->calculate_level = Reaction_calculate_level;
+  self->get_level = Reaction_get_level;
+  self->index = index;
+  self->level = -1;
 }

--- a/src/reactor.c
+++ b/src/reactor.c
@@ -4,9 +4,20 @@
 
 #include <string.h>
 
-void register_startup(Reactor *self, Startup *startup) {
+void Reactor_register_startup(Reactor *self, Startup *startup) {
   (void)self;
   startup->super.schedule_at((Trigger *)startup, ZERO_TAG);
+}
+
+void Reactor_calculate_levels(Reactor *self) {
+  for (size_t i = 0; i < self->reactions_size; i++) {
+    size_t level = self->reactions[i]->get_level(self->reactions[i]);
+    (void)level;
+  }
+
+  for (size_t i = 0; i < self->children_size; i++) {
+    Reactor_calculate_levels(self->children[i]);
+  }
 }
 
 void Reactor_ctor(Reactor *self, const char *name, Environment *env, Reactor **children, size_t children_size,
@@ -20,5 +31,6 @@ void Reactor_ctor(Reactor *self, const char *name, Environment *env, Reactor **c
   self->triggers_size = triggers_size;
   self->reactions = reactions;
   self->reactions_size = reactions_size;
-  self->register_startup = register_startup;
+  self->register_startup = Reactor_register_startup;
+  self->calculate_levels = Reactor_calculate_levels;
 }

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -11,10 +11,9 @@ static void reset_is_present_recursive(Reactor *reactor) {
   }
 }
 
-void Scheduler_prepare_timestep(Scheduler *self) { (void)self; }
+void Scheduler_prepare_timestep(Scheduler *self) { self->reaction_queue.reset(&self->reaction_queue); }
 
 void Scheduler_clean_up_timestep(Scheduler *self) {
-  self->reaction_queue.reset(&self->reaction_queue);
 
   // FIXME: Improve this expensive resetting of all `is_present` fields of triggers.
 


### PR DESCRIPTION
@tanneberger Here I port your level assignment implementation and put it in the runtime (instead of requiring it to be code-generated). Still missing causality cycle check though.