### PR TITLE
Add Shutdown trigger and handle program exit

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,3 +9,6 @@ target_link_libraries(hello_timer reactor-uc)
 
 add_executable(port_ex port_ex.c) 
 target_link_libraries(port_ex reactor-uc)
+
+add_executable(shutdown_ex shutdown_ex.c) 
+target_link_libraries(shutdown_ex reactor-uc)

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -43,11 +43,11 @@ void MyReactor_ctor(MyReactor *self, Environment *env) {
   self->super.register_startup(&self->super, &self->startup.super);
 }
 
+MyReactor my_reactor;
 int main() {
-  Environment env;
-  MyReactor my_reactor;
-  Environment_ctor(&env, (Reactor *)&my_reactor);
-  MyReactor_ctor(&my_reactor, &env);
-  env.assemble(&env);
-  env.start(&env);
+  Environment *env = &lf_global_env;
+  Environment_ctor(env, (Reactor *)&my_reactor);
+  MyReactor_ctor(&my_reactor, env);
+  env->assemble(env);
+  env->start(env);
 }

--- a/examples/hello_action.c
+++ b/examples/hello_action.c
@@ -71,11 +71,11 @@ void MyReactor_ctor(struct MyReactor *self, Environment *env) {
   self->cnt = 0;
 }
 
+struct MyReactor my_reactor;
 int main() {
-  struct MyReactor my_reactor;
-  Environment env;
-  Environment_ctor(&env, (Reactor *)&my_reactor);
-  MyReactor_ctor(&my_reactor, &env);
-  env.assemble(&env);
-  env.start(&env);
+  Environment *env = &lf_global_env;
+  Environment_ctor(env, (Reactor *)&my_reactor);
+  MyReactor_ctor(&my_reactor, env);
+  env->assemble(env);
+  env->start(env);
 }

--- a/examples/hello_timer.c
+++ b/examples/hello_timer.c
@@ -40,11 +40,11 @@ void MyReactor_ctor(struct MyReactor *self, Environment *env) {
   self->timer.super.super.register_effect(&self->timer.super.super, &self->my_reaction.super);
 }
 
+struct MyReactor my_reactor;
 int main() {
-  struct MyReactor my_reactor;
-  Environment env;
-  Environment_ctor(&env, (Reactor *)&my_reactor);
-  MyReactor_ctor(&my_reactor, &env);
-  env.assemble(&env);
-  env.start(&env);
+  Environment *env = &lf_global_env;
+  Environment_ctor(env, (Reactor *)&my_reactor);
+  MyReactor_ctor(&my_reactor, env);
+  env->assemble(env);
+  env->start(env);
 }

--- a/examples/port_ex.c
+++ b/examples/port_ex.c
@@ -135,11 +135,11 @@ void Main_ctor(struct Main *self, Environment *env) {
   Reactor_ctor(&self->super, "Main", env, self->_children, 2, NULL, 0, NULL, 0);
 }
 
+struct Main main;
 int main() {
-  struct Main main;
-  Environment env;
-  Environment_ctor(&env, (Reactor *)&main);
-  Main_ctor(&main, &env);
-  env.assemble(&env);
-  env.start(&env);
+  Environment *env = &lf_global_env;
+  Environment_ctor(env, (Reactor *)&main);
+  Main_ctor(&main, env);
+  env->assemble(env);
+  env->start(env);
 }

--- a/examples/shutdown_ex.c
+++ b/examples/shutdown_ex.c
@@ -1,0 +1,81 @@
+
+#include "reactor-uc/reactor-uc.h"
+
+typedef struct {
+  Startup super;
+  Reaction *effects_[1];
+} MyStartup;
+
+typedef struct {
+  Shutdown super;
+  Reaction *effects_[1];
+} MyShutdown;
+
+typedef struct {
+  Reaction super;
+} Reaction1;
+
+typedef struct {
+  Reaction super;
+} Reaction2;
+
+typedef struct {
+  Reactor super;
+  Reaction1 reaction1;
+  Reaction2 reaction2;
+  MyStartup startup;
+  MyShutdown shutdown;
+  Reaction *_reactions[2];
+  Trigger *_triggers[2];
+} MyReactor;
+
+void MyStartup_ctor(MyStartup *self, MyReactor *parent) {
+  Startup_ctor(&self->super, &parent->super, self->effects_, 1);
+  self->super.super.register_effect(&self->super.super, &parent->reaction1.super);
+}
+
+int Reaction1_body(Reaction *_self) {
+  printf("Startup reaction executing\n");
+  return 0;
+}
+
+void Reaction1_ctor(Reaction1 *self, Reactor *parent) {
+  Reaction_ctor(&self->super, parent, Reaction1_body, NULL, 0, 0);
+}
+
+void MyShutdown_ctor(MyShutdown *self, MyReactor *parent) {
+  Shutdown_ctor(&self->super, &parent->super, self->effects_, 1);
+  self->super.super.register_effect(&self->super.super, &parent->reaction2.super);
+}
+
+int Reaction2_body(Reaction *_self) {
+  printf("Shutdown reaction executing\n");
+  return 0;
+}
+
+void Reaction2_ctor(Reaction2 *self, Reactor *parent) {
+  Reaction_ctor(&self->super, parent, Reaction2_body, NULL, 0, 0);
+}
+
+void MyReactor_ctor(MyReactor *self, Environment *env) {
+  self->_reactions[0] = (Reaction *)&self->reaction1;
+  self->_reactions[1] = (Reaction *)&self->reaction2;
+  self->_triggers[0] = (Trigger *)&self->startup;
+  self->_triggers[1] = (Trigger *)&self->shutdown;
+  Reactor_ctor(&self->super, "MyReactor", env, NULL, 0, self->_reactions, 2, self->_triggers, 2);
+  Reaction1_ctor(&self->reaction1, &self->super);
+  Reaction2_ctor(&self->reaction2, &self->super);
+  MyStartup_ctor(&self->startup, self);
+  MyShutdown_ctor(&self->shutdown, self);
+  self->super.register_startup(&self->super, &self->startup.super);
+  self->super.register_shutdown(&self->super, &self->shutdown.super);
+}
+
+MyReactor my_reactor;
+int main() {
+  Environment *env = &lf_global_env;
+  Environment_ctor(env, (Reactor *)&my_reactor);
+  MyReactor_ctor(&my_reactor, env);
+  env->assemble(env);
+  env->start(env);
+}

--- a/include/reactor-uc/builtin_triggers.h
+++ b/include/reactor-uc/builtin_triggers.h
@@ -6,6 +6,7 @@
 #include "reactor-uc/trigger.h"
 
 typedef struct Startup Startup;
+typedef struct Shutdown Shutdown;
 
 struct Startup {
   Trigger super;
@@ -13,4 +14,9 @@ struct Startup {
 
 void Startup_ctor(Startup *self, Reactor *parent, Reaction **effects, size_t effects_size);
 
+struct Shutdown {
+  Trigger super;
+};
+
+void Shutdown_ctor(Shutdown *self, Reactor *parent, Reaction **effects, size_t effects_size);
 #endif

--- a/include/reactor-uc/environment.h
+++ b/include/reactor-uc/environment.h
@@ -1,23 +1,28 @@
 #ifndef REACTOR_UC_ENVIRONMENT_H
 #define REACTOR_UC_ENVIRONMENT_H
 
+#include "reactor-uc/builtin_triggers.h"
 #include "reactor-uc/reactor.h"
 #include "reactor-uc/scheduler.h"
+
+extern Environment lf_global_env;
 
 typedef struct Environment Environment;
 
 struct Environment {
   Reactor *main;
   Scheduler scheduler;
+  tag_t stop_tag;
   tag_t current_tag;
   bool keep_alive;
+  Startup *startup;
+  Shutdown *shutdown;
   void (*assemble)(Environment *self);
   void (*start)(Environment *self);
   int (*wait_until)(Environment *self, instant_t wakeup_time);
+  void (*terminate)(Environment *self);
 };
 
 void Environment_ctor(Environment *self, Reactor *main);
-void Environment_assemble(Environment *self);
-void Environment_start(Environment *self);
 
 #endif

--- a/include/reactor-uc/reactor.h
+++ b/include/reactor-uc/reactor.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 
 typedef struct Startup Startup;
+typedef struct Shutdown Shutdown;
 typedef struct Reactor Reactor;
 typedef struct Environment Environment;
 typedef struct Startup Startup;
@@ -15,6 +16,7 @@ struct Reactor {
   Environment *env;
   void (*assemble)(Reactor *self);
   void (*register_startup)(Reactor *self, Startup *startup);
+  void (*register_shutdown)(Reactor *self, Shutdown *shutdown);
   void (*calculate_levels)(Reactor *self);
   Reactor **children;
   size_t children_size;

--- a/include/reactor-uc/scheduler.h
+++ b/include/reactor-uc/scheduler.h
@@ -13,6 +13,9 @@ struct Scheduler {
   void (*run)(Scheduler *self);
   void (*prepare_timestep)(Scheduler *self);
   void (*clean_up_timestep)(Scheduler *self);
+  void (*run_timestep)(Scheduler *self);
+  void (*terminate)(Scheduler *self);
+  void (*trigger_reactions)(Scheduler *self, Trigger *trigger);
 };
 
 void Scheduler_ctor(Scheduler *self, Environment *env);

--- a/include/reactor-uc/trigger.h
+++ b/include/reactor-uc/trigger.h
@@ -7,7 +7,7 @@
 
 typedef struct Trigger Trigger;
 
-typedef enum { ACTION, TIMER, BUILTIN, INPUT, OUTPUT } TriggerType;
+typedef enum { ACTION, TIMER, STARTUP, SHUTDOWN, INPUT, OUTPUT } TriggerType;
 
 typedef void (*Trigger_update_value)(Trigger *self);
 struct Trigger {
@@ -21,6 +21,7 @@ struct Trigger {
   size_t sources_registered;
   Trigger_update_value update_value;
   bool is_present;
+  Trigger *next; // For chaining together triggers, e.g. shutdown/startup triggers.
   void (*schedule_at)(Trigger *, tag_t);
   void (*register_effect)(Trigger *, Reaction *);
   void (*register_source)(Trigger *, Reaction *);

--- a/src/builtin_triggers.c
+++ b/src/builtin_triggers.c
@@ -1,6 +1,9 @@
 #include "reactor-uc/builtin_triggers.h"
 
-void Startup_start(Trigger *self) { (void)self; }
 void Startup_ctor(Startup *self, Reactor *parent, Reaction **effects, size_t effects_size) {
-  Trigger_ctor((Trigger *)self, BUILTIN, parent, effects, effects_size, NULL, 0, Startup_start);
+  Trigger_ctor((Trigger *)self, STARTUP, parent, effects, effects_size, NULL, 0, NULL);
+}
+
+void Shutdown_ctor(Shutdown *self, Reactor *parent, Reaction **effects, size_t effects_size) {
+  Trigger_ctor((Trigger *)self, SHUTDOWN, parent, effects, effects_size, NULL, 0, NULL);
 }

--- a/src/port.c
+++ b/src/port.c
@@ -6,9 +6,7 @@
 void InputPort_trigger_effects(InputPort *self) {
   assert(self->super.super.type == INPUT);
   Scheduler *sched = &self->super.super.parent->env->scheduler;
-  for (size_t j = 0; j < self->super.super.effects_size; j++) {
-    sched->reaction_queue.insert(&sched->reaction_queue, self->super.super.effects[j]);
-  }
+  sched->trigger_reactions(sched, (Trigger *)self);
 }
 
 void InputPort_ctor(InputPort *self, Reactor *parent, Reaction **effects, size_t effects_size, void **value_ptr_ptr) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -13,39 +13,69 @@ static void reset_is_present_recursive(Reactor *reactor) {
 
 void Scheduler_prepare_timestep(Scheduler *self) { self->reaction_queue.reset(&self->reaction_queue); }
 
+void Scheduler_trigger_reactions(Scheduler *self, Trigger *trigger) {
+  for (size_t i = 0; i < trigger->effects_size; i++) {
+    self->reaction_queue.insert(&self->reaction_queue, trigger->effects[i]);
+  }
+}
+
+void Scheduler_run_timestep(Scheduler *self) {
+  while (!self->reaction_queue.empty(&self->reaction_queue)) {
+    Reaction *reaction = self->reaction_queue.pop(&self->reaction_queue);
+    reaction->body(reaction);
+  }
+}
+
+void Scheduler_terminate(Scheduler *self) {
+  printf("Scheduler terminating\n");
+  self->reaction_queue.reset(&self->reaction_queue);
+  Trigger *shutdown = &self->env->shutdown->super;
+  while (shutdown) {
+    self->trigger_reactions(self, shutdown);
+    shutdown = shutdown->next;
+  }
+  self->run_timestep(self);
+}
+
 void Scheduler_clean_up_timestep(Scheduler *self) {
-
-  // FIXME: Improve this expensive resetting of all `is_present` fields of triggers.
-
+  // TODO: Improve this expensive resetting of all `is_present` fields of triggers.
   Environment *env = self->env;
   reset_is_present_recursive(env->main);
 }
 void Scheduler_run(Scheduler *self) {
+  bool do_shutdown = false;
   while (!self->event_queue.empty(&self->event_queue)) {
     tag_t next_tag = self->event_queue.next_tag(&self->event_queue);
+    if (lf_tag_compare(next_tag, self->env->stop_tag) >= 0) {
+      next_tag = self->env->stop_tag;
+      do_shutdown = true;
+    }
     self->env->wait_until(self->env, next_tag.time);
+    if (do_shutdown)
+      break;
+
     do {
       self->prepare_timestep(self);
       Event event = self->event_queue.pop(&self->event_queue);
       self->env->current_tag = event.tag;
-      event.trigger->is_present = true;
-      if (event.trigger->update_value) {
-        event.trigger->update_value(event.trigger);
-      }
 
-      // TODO: Move this to a function `self->trigger_reactions(self, event.trigger);
-      for (size_t i = 0; i < event.trigger->effects_size; i++) {
-        self->reaction_queue.insert(&self->reaction_queue, event.trigger->effects[i]);
-      }
+      Trigger *trigger = event.trigger;
+      do {
+        trigger->is_present = true;
+        if (trigger->update_value) {
+          trigger->update_value(event.trigger);
+        }
+        self->trigger_reactions(self, trigger);
+
+        trigger = trigger->next;
+      } while (trigger);
     } while (lf_tag_compare(next_tag, self->event_queue.next_tag(&self->event_queue)) == 0);
 
-    while (!self->reaction_queue.empty(&self->reaction_queue)) {
-      Reaction *reaction = self->reaction_queue.pop(&self->reaction_queue);
-      reaction->body(reaction);
-    }
+    self->run_timestep(self);
     self->clean_up_timestep(self);
   }
-  printf("Scheduler out of events. Shutting down.\n");
+
+  // self->terminate(self);
 }
 
 void Scheduler_ctor(Scheduler *self, Environment *env) {
@@ -53,6 +83,9 @@ void Scheduler_ctor(Scheduler *self, Environment *env) {
   self->run = Scheduler_run;
   self->prepare_timestep = Scheduler_prepare_timestep;
   self->clean_up_timestep = Scheduler_clean_up_timestep;
+  self->trigger_reactions = Scheduler_trigger_reactions;
+  self->run_timestep = Scheduler_run_timestep;
+  self->terminate = Scheduler_terminate;
   EventQueue_ctor(&self->event_queue);
   ReactionQueue_ctor(&self->reaction_queue);
 }

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -28,6 +28,8 @@ void Trigger_ctor(Trigger *self, TriggerType type, Reactor *parent, Reaction **e
   self->sources_size = sources_size;
   self->sources_registered = 0;
   self->update_value = update_value_func;
+  self->next = NULL;
+  self->is_present = false;
 
   self->schedule_at = Trigger_schedule_at;
   self->register_effect = Trigger_register_effect;


### PR DESCRIPTION
This unfortunately messes a little with gcov and we get warnings:
```
libgcov profiling error:/home/erling/dev/reactor-uc/build/CMakeFiles/reactor-uc.dir/src/trigger.c.gcda:overwriting an existing profile data with a different timestamp
```

Presumably when the shutdown reactor is executed. 