### PR TITLE
Use Justfile instead of Makefile for shorthand commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
         with:
             submodules: recursive
       - name: Install deps
-        run: sudo apt-get install lcov
+        run: sudo apt-get install lcov just
       - name: Run tests
         run: |
-          make format-check
+          just format-check
           cmake -Bbuild && cd build
           cmake --build .
-          make test
-          make coverage
+          just test
+          just coverage
       - name: Coverage
         uses: romeovs/lcov-reporter-action@2a28ec3e25fb7eae9cb537e9141603486f810d1a
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 project(reactor-uc LANGUAGES C)
 
-set(BUILD_TESTS ON CACHE BOOL "Build unit tests")
-set(BUILD_EXAMPLES ON CACHE BOOL "Build example programs")
-set(TEST_COVERAGE ON CACHE BOOL "Compute test coverage")
+set(BUILD_TESTS OFF CACHE BOOL "Build unit tests")
+set(BUILD_EXAMPLES OFF CACHE BOOL "Build example programs")
+set(TEST_COVERAGE OFF CACHE BOOL "Compute test coverage")
 set(ASAN OFF CACHE BOOL "Compile with AddressSanitizer")
 set(PLATFORM "POSIX" CACHE STRING "Platform to target")
 
@@ -20,12 +20,14 @@ if(ASAN)
 endif()
 
 # Clang-tidy setup
-# find_program(CLANG_TIDY clang-tidy)
-# if (CLANG_TIDY)
-#   set(CMAKE_C_CLANG_TIDY clang-tidy; --header-filter=include/\(.*\)\\.h; --warnings-as-errors)
-# else ()
-#   message(WARNING "Please install clang-tidy!")
-# endif()
+find_program(CLANG_TIDY clang-tidy)
+if (BUILD_TESTS)
+  if (CLANG_TIDY)
+    set(CMAKE_C_CLANG_TIDY clang-tidy; --header-filter=include/\(.*\)\\.h; --warnings-as-errors)
+  else ()
+    message(WARNING "Please install clang-tidy!")
+  endif()
+endif()
 
 
 file(GLOB SOURCES "src/*.c")

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,31 @@
+# Test Target
+test:
+    cmake -B build
+    cmake --build build
+    make test -C build
+
+# Clean Target
+clean:
+    rm -r build
+
+# Coverage Target
+coverage:
+    cmake -B build
+    cmake --build build
+    make coverage -C build
+
+# ASAN Target
+asan:
+    cmake -B build -DASAN=ON
+    cmake --build build
+    make test -C build
+
+# Format Code
+src_files := `find src -name '*.c'`
+hdr_files := `find include -name '*.h'`
+format:
+    clang-format -i -style=file {{src_files}} {{hdr_files}}
+
+# Format Check
+format-check:
+    clang-format --dry-run --Werror -style=file {{src_files}} {{hdr_files}}


### PR DESCRIPTION
So we can use the Makefile for integration into RIOT and other Makefile based frameworks