### PR TITLE
Add support for Physical connections

### DIFF
--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMainGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMainGenerator.kt
@@ -2,6 +2,7 @@ package org.lflang.generator.uc
 
 import org.lflang.target.TargetConfig
 import org.lflang.generator.PrependOperator
+import org.lflang.generator.uc.UcReactorGenerator.Companion.codeType
 import org.lflang.inferredType
 import org.lflang.lf.Parameter
 import org.lflang.lf.Reactor
@@ -39,11 +40,11 @@ class UcMainGenerator(
             |#include "reactor-uc/reactor-uc.h"
             |#include "${fileConfig.getReactorHeaderPath(main).toUnixString()}"
             |static Environment env;
-            |static ${main.name} main_reactor;
+            |static ${main.codeType} main_reactor;
             |void lf_main(void) {
             |   Environment_ctor(&env, &main_reactor.super);
             |   ${if (targetConfig.isSet(TimeOutProperty.INSTANCE)) "env.set_stop_time(&env, ${targetConfig.get(TimeOutProperty.INSTANCE).toCCode()});" else ""}
-            |   ${main.name}_ctor(&main_reactor, &env, NULL);
+            |   ${main.codeType}_ctor(&main_reactor, &env, NULL);
             |   env.assemble(&env);
             |   env.start(&env);
             |}

--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcReactionGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcReactionGenerator.kt
@@ -1,31 +1,8 @@
-/*************
- * Copyright (c) 2021, TU Dresden.
-
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
-
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
-
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
-
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- ***************/
-
 package org.lflang.generator.uc
 
 import org.lflang.*
 import org.lflang.generator.PrependOperator
+import org.lflang.generator.uc.UcReactorGenerator.Companion.codeType
 import org.lflang.lf.*
 
 class UcReactionGenerator(
@@ -134,7 +111,7 @@ class UcReactionGenerator(
         """
             |static void ${reaction.bodyFuncName}(Reaction *_self) {
             |   // Bring expected variable names into scope
-            |   ${reactor.name} *self = (${reactor.name} *) _self->parent;
+            |   ${reactor.codeType} *self = (${reactor.codeType} *) _self->parent;
             |   Environment *env = self->super.env;
             |   ${generateTriggersInScope(reaction)}
             |   // Start of user-witten reaction body

--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcReactorGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcReactorGenerator.kt
@@ -39,7 +39,7 @@ class UcReactorGenerator(private val reactor: Reactor, fileConfig: UcFileConfig,
 
     companion object {
         val Reactor.codeType
-            get(): String = this.name
+            get(): String = "Reactor_$name"
     }
 
     fun generateReactorStruct() = with(PrependOperator) {
@@ -76,7 +76,7 @@ class UcReactorGenerator(private val reactor: Reactor, fileConfig: UcFileConfig,
             | // The reactor self struct
         ${" |"..generateReactorStruct()}
             | // The constructor for the self struct
-            |void ${reactor.name}_ctor(${reactor.name} *self, Environment *env, Reactor *parent${parameters.generateReactorCtorDefArguments()});
+            |void ${reactor.codeType}_ctor(${reactor.codeType} *self, Environment *env, Reactor *parent${parameters.generateReactorCtorDefArguments()});
             |
             |
         """.trimMargin()
@@ -97,7 +97,7 @@ class UcReactorGenerator(private val reactor: Reactor, fileConfig: UcFileConfig,
 
     fun generateCtorDefinition() = with(PrependOperator) {
         """
-            |void ${reactor.name}_ctor(${reactor.name} *self, Environment *env, Reactor *parent${parameters.generateReactorCtorDefArguments()}) {
+            |void ${reactor.codeType}_ctor(${reactor.codeType} *self, Environment *env, Reactor *parent${parameters.generateReactorCtorDefArguments()}) {
             |   size_t trigger_idx = 0;
             |   size_t child_idx = 0;
             |   Reactor_ctor(&self->super, "${reactor.name}", env, parent, ${if (numChildren > 0) "self->_children" else "NULL"}, $numChildren, ${if (reactor.reactions.size > 0) "self->_reactions" else "NULL"}, ${reactor.reactions.size}, ${if (numTriggers() > 0) "self->_triggers" else "NULL"}, ${numTriggers()});

--- a/test/lf/src/PhysicalConnection.lf
+++ b/test/lf/src/PhysicalConnection.lf
@@ -1,0 +1,26 @@
+target uC
+
+reactor Sender {
+  output out: int
+  timer t(10 msec)
+  reaction(t) -> out {=
+    lf_set(out, 42);
+  =}
+}
+
+reactor Recv {
+  input in: int
+  reaction(in) {=
+    interval_t now_l = env->get_elapsed_logical_time(env);
+    interval_t now_p = env->get_elapsed_physical_time(env);
+    assert(now_l > MSEC(10) + MSEC(500));
+    assert(lf_get(in) == 42);
+  =}
+}
+
+main reactor {
+  s = new Sender()
+  r = new Recv()
+
+  s.out ~> r.in after 500 msec
+}


### PR DESCRIPTION
Also make all generated Reactor self structs be prepended by `Reactor_`. Before this change we could not have a reactor named e.g. PhysicalConnection because it would collide with reactor-uc defined struct with the same name
