### PR TITLE
Fix spelling of wait_until_interruptible and make platform/riot.c compile

### DIFF
--- a/include/reactor-uc/platform.h
+++ b/include/reactor-uc/platform.h
@@ -24,11 +24,11 @@ struct Platform {
    * @brief Put the system to sleep until the wakeup time or until an
    * asynchronous event occurs.
    */
-  lf_ret_t (*wait_until_interruptable)(Platform *self, instant_t wakeup_time);
+  lf_ret_t (*wait_until_interruptible)(Platform *self, instant_t wakeup_time);
 
   /**
    * @brief Signal the occurrence of an asynchronous event. This should wake
-   * up the platform if it is sleeping on `wait_until_interruptable`.
+   * up the platform if it is sleeping on `wait_until_interruptible`.
    */
   void (*new_async_event)(Platform *self);
 

--- a/src/environment.c
+++ b/src/environment.c
@@ -15,7 +15,7 @@ lf_ret_t Environment_wait_until(Environment *self, instant_t wakeup_time) {
   }
 
   if (self->has_async_events) {
-    return self->platform->wait_until_interruptable(self->platform, wakeup_time);
+    return self->platform->wait_until_interruptible(self->platform, wakeup_time);
   } else {
     return self->platform->wait_until(self->platform, wakeup_time);
   }

--- a/src/platform/posix/posix.c
+++ b/src/platform/posix/posix.c
@@ -40,7 +40,7 @@ instant_t PlatformPosix_get_physical_time(Platform *self) {
   return convert_timespec_to_ns(tspec);
 }
 
-lf_ret_t PlatformPosix_wait_until_interruptable(Platform *_self, instant_t wakeup_time) {
+lf_ret_t PlatformPosix_wait_until_interruptible(Platform *_self, instant_t wakeup_time) {
   LF_DEBUG(PLATFORM, "Interruptable wait until %" PRId64, wakeup_time);
   PlatformPosix *self = (PlatformPosix *)_self;
   const struct timespec tspec = convert_ns_to_timespec(wakeup_time);
@@ -96,7 +96,7 @@ void Platform_ctor(Platform *self) {
   self->get_physical_time = PlatformPosix_get_physical_time;
   self->wait_until = PlatformPosix_wait_until;
   self->initialize = PlatformPosix_initialize;
-  self->wait_until_interruptable = PlatformPosix_wait_until_interruptable;
+  self->wait_until_interruptible = PlatformPosix_wait_until_interruptible;
   self->new_async_event = PlatformPosix_new_async_event;
 }
 

--- a/src/platform/zephyr/zephyr.c
+++ b/src/platform/zephyr/zephyr.c
@@ -40,7 +40,7 @@ lf_ret_t PlatformZephyr_wait_until(Platform *self, instant_t wakeup_time) {
   }
 }
 
-lf_ret_t PlatformZephyr_wait_until_interruptable(Platform *self, instant_t wakeup_time) {
+lf_ret_t PlatformZephyr_wait_until_interruptible(Platform *self, instant_t wakeup_time) {
   PlatformZephyr *p = (PlatformZephyr *)self;
   LF_DEBUG(PLATFORM, "Wait until interruptable %" PRId64, wakeup_time);
   interval_t sleep_duration = wakeup_time - self->get_physical_time(self);
@@ -89,7 +89,7 @@ void Platform_ctor(Platform *self) {
   self->get_physical_time = PlatformZephyr_get_physical_time;
   self->wait_until = PlatformZephyr_wait_until;
   self->initialize = PlatformZephyr_initialize;
-  self->wait_until_interruptable = PlatformZephyr_wait_until_interruptable;
+  self->wait_until_interruptible = PlatformZephyr_wait_until_interruptible;
   self->new_async_event = PlatformZephyr_new_async_event;
 }
 


### PR DESCRIPTION
Partially this is to fix a typo and partially it also fixes the compilation of riot.c

Funnily the type did not exist in riot.c so riot.c did not compile :)

I think fixing the typo in the rest of the runtime is more reasonable to make riot.c inherit the typo 