### PR TITLE
Fixed bug with reactions triggered my multiple inputs

### DIFF
--- a/src/queues.c
+++ b/src/queues.c
@@ -129,7 +129,7 @@ static lf_ret_t ReactionQueue_insert(ReactionQueue* self, Reaction* reaction) {
   validate(reaction);
   validate(reaction->level < (int)self->capacity);
   validate(reaction->level >= 0);
-  
+
   validate(self->curr_level <= reaction->level);
 
   // checking if the reaction to be inserted is already in the queue


### PR DESCRIPTION
There is a bug that causes an assertion on the reaction queue capacity to fail. This bug occurrs with reactions triggered by two or more input ports at the same logical time, with the input ports receiving data from other federates. The failing assertion is in the _queues.c_ file, in the `ReactionQueue_insert` function called to insert the triggered reaction in the reaction queue. The assertion checks that the reaction queue has enough space to insert the triggered reaction:
```
validate(self->level_size[reaction->level] < (int)self->capacity);
```
When two inputs trigger the same reaction, the reaction is inserted in the reaction queue only once. Indeed, this `for` loop checks whether the reaction is already in the queue and, if that is the case, the insertion function returns:
```
for (int i = 0; i < self->level_size[reaction->level]; i++) {
    if (ACCESS(self->array, self->capacity, reaction->level, i) == reaction) {
      return LF_OK;
    }
}
```
This check is performed _after_ the assertion on the capacity. This PR swaps them to ensure that checking if the reaction is already in the queue is done before the check on the capacity of the reaction queue. [Multitrigger.lf.txt](https://github.com/user-attachments/files/25058746/Multitrigger.lf.txt) is an example LF program that does not work without this fix:
<img width="964" height="410" alt="image" src="https://github.com/user-attachments/assets/a8185798-69b8-4811-be07-58637c439b52" />