### PR TITLE
Fix state time variable type

### DIFF
--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcStateGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcStateGenerator.kt
@@ -3,9 +3,9 @@ package org.lflang.generator.uc
 import org.lflang.allStateVars
 import org.lflang.generator.uc.UcPortGenerator.Companion.arrayLength
 import org.lflang.generator.uc.UcPortGenerator.Companion.isArray
+import org.lflang.inferredType
 import org.lflang.isInitialized
 import org.lflang.lf.Reactor
-import org.lflang.toText
 
 class UcStateGenerator(private val reactor: Reactor) {
   fun generateReactorStructFields() =
@@ -13,7 +13,7 @@ class UcStateGenerator(private val reactor: Reactor) {
         if (it.type.isArray) {
           "${it.type.id} ${it.name}[${it.type.arrayLength}];"
         } else {
-          "${it.type.toText()} ${it.name};"
+          "${it.inferredType.CType} ${it.name};"
         }
       }
 

--- a/test/lf/src/StateTime.lf
+++ b/test/lf/src/StateTime.lf
@@ -1,0 +1,27 @@
+target uC
+
+// A state variable of type `time` must translate to the
+// target time type (interval_t), exactly like a `time` parameter does.
+@platform("native")
+main reactor StateTime(start: time = 100 ms, incr: time = 100 ms) {
+  state interval: time = start
+  state count: int = 0
+  logical action a
+
+  reaction(startup) -> a {=
+    lf_schedule(a, self->start);
+  =}
+
+  reaction(a) -> a {=
+    interval_t elapsed = env->get_elapsed_logical_time(env);
+    printf("**** elapsed=%lld interval=%lld\n", elapsed, self->interval);
+    validate(elapsed == self->interval);
+    if (self->count >= 3) {
+      env->request_shutdown(env, MSEC(0));
+    } else {
+      self->interval += self->incr;
+      self->count++;
+      lf_schedule(a, self->incr);
+    }
+  =}
+}


### PR DESCRIPTION
Fix code generation for state variables, ensuring that state variables of type `time` are correctly mapped to the target's time type (`interval_t`). It also adds a new test to verify this behavior.

Closes #368